### PR TITLE
This isn't an interoperability requirement

### DIFF
--- a/draft-ietf-tls-exported-authenticator.md
+++ b/draft-ietf-tls-exported-authenticator.md
@@ -313,7 +313,7 @@ The "authenticate" takes as input:
 to perform private key operation) for each chain
 * an optional authenticator request or certificate_request_context (from 0 to 255 bytes)
 
-It returns the exported authenticator as a sequence of octets.  It is RECOMMENDED that
+It returns the exported authenticator as a sequence of octets.  Ideally,
 the logic for selecting the certificates and extensions to include
 in the exporter is implemented in the TLS library.  Implementing this
 in the TLS library lets the implementer take advantage of existing


### PR DESCRIPTION
It's also the only use of 2119 language in this section, which is otherwise nicely informative.