### PR TITLE
Make authenticator_request presence consistent for clients

### DIFF
--- a/draft-ietf-tls-exported-authenticator.md
+++ b/draft-ietf-tls-exported-authenticator.md
@@ -129,8 +129,9 @@ to keep the certificate confidential.
 
 An authenticator message can be constructed by either the client or the
 server given an established TLS connection, a certificate, and a corresponding
-private key.  For clients, an authenticator request is required; for servers
-an authenticator request is optional.  The authenticator uses the message
+private key.  Clients MUST NOT send an authenticator without a preceding 
+authenticator request is required; for servers an authenticator request 
+is optional.  The authenticator uses the message
 structures from Section 4.4 of {{!TLS13}}, but different
 parameters.  These messages do not include the TLS record layer and are
 therefore not encrypted with a handshake key.
@@ -169,9 +170,7 @@ Certificate, CertificateVerify, and Finished messages.
 If an authenticator request is present, the extensions used to guide the
 construction of these messages are taken from the authenticator request. If
 there is no authenticator request, the extensions are chosen from the TLS
-handshake. That is, the extensions received in a ClientHello (for servers),
-ServerHello (for clients in TLS 1.2), or EncryptedExtensions (for clients in
-TLS 1.3).
+handshake. That is, the extensions received in a ClientHello (for servers).
 
 ### Certificate
 

--- a/draft-ietf-tls-exported-authenticator.md
+++ b/draft-ietf-tls-exported-authenticator.md
@@ -130,11 +130,10 @@ to keep the certificate confidential.
 An authenticator message can be constructed by either the client or the
 server given an established TLS connection, a certificate, and a corresponding
 private key.  Clients MUST NOT send an authenticator without a preceding 
-authenticator request is required; for servers an authenticator request 
-is optional.  The authenticator uses the message
-structures from Section 4.4 of {{!TLS13}}, but different
-parameters.  These messages do not include the TLS record layer and are
-therefore not encrypted with a handshake key.
+authenticator request; for servers an authenticator request is optional.  
+The authenticator uses the message structures from Section 4.4 of {{!TLS13}}, 
+but different parameters.  These messages do not include the TLS record layer 
+and are therefore not encrypted with a handshake key.
 
 ## Authenticator Keys
 

--- a/draft-ietf-tls-exported-authenticator.md
+++ b/draft-ietf-tls-exported-authenticator.md
@@ -169,7 +169,9 @@ Certificate, CertificateVerify, and Finished messages.
 If an authenticator request is present, the extensions used to guide the
 construction of these messages are taken from the authenticator request. If
 there is no authenticator request, the extensions are chosen from the TLS
-handshake. That is, the extensions received in a ClientHello (for servers).
+handshake. Only servers can provide an authenticator without a corresponding 
+request. In such cases, ClientHello extensions are used to determine permissible
+extensions in the Certificate message.
 
 ### Certificate
 


### PR DESCRIPTION
In Section 4, clients are required to have an authenticator request before generating and sending an authenticator. Later, in Section 4.2, the draft states that clients may get authenticator information from a SH or EncryptedExtensions in the event that no authenticator request is present. This seems to contradict the requirement in Section 4. 