### PR TITLE
Remove 'get context' API

### DIFF
--- a/draft-ietf-tls-exported-authenticator.md
+++ b/draft-ietf-tls-exported-authenticator.md
@@ -323,14 +323,6 @@ The "request" API takes as input:
 
 It returns an authenticator request, which is a sequence of octets that includes a CertificateRequest message.
 
-## The "get context" API
-
-The "get context" API takes as input:
-
-* authenticator
-
-It returns the certificate_request_context.
-
 ## The "authenticate" API
 
 The "authenticate" takes as input:


### PR DESCRIPTION
This API doesn't seem particularly useful, since the authenticator is passed
to the "validate" API as-is so there's no need for the application to know
its certificate_request_context.

Though maybe I misunderstood what this is for.