### PR TITLE
Add warning about agreement on Client certificate bytes.

### DIFF
--- a/draft-ietf-tls-exported-authenticator.md
+++ b/draft-ietf-tls-exported-authenticator.md
@@ -513,8 +513,8 @@ protocols.
 
 In TLS 1.3 the client can not explicitly learn from the TLS layer whether its
 Finished message was accepted. Because the application traffic keys are not
-dependent on the client's final flight, the client cannot learn whether the
-server ever received it.  To avoid disagreement between the client and server
+dependent on the client's final flight, receiving messages from the server
+does not prove that the server received the client's Finished. To avoid disagreement between the client and server
 on the authentication status of EAs, servers MUST verify the client Finished
 before sending an EA or processing a received EA.
 

--- a/draft-ietf-tls-exported-authenticator.md
+++ b/draft-ietf-tls-exported-authenticator.md
@@ -514,7 +514,7 @@ protocols.
 In TLS 1.3 the client and server are not guaranteed to agree on the client’s
 final flight until the first application message.  Because EAs can be
 negotiated out-of-band it is possible to negotiate EAs without agreeing on the
-entire transcript.  Servers SHOULD send application data before sending an
+entire transcript.  Servers SHOULD send application data before sending a
 CertificateRequest to the client.  If there is no application data to send the
 server MAY send a NewSessionTicket.
 

--- a/draft-ietf-tls-exported-authenticator.md
+++ b/draft-ietf-tls-exported-authenticator.md
@@ -511,12 +511,12 @@ The signatures generated with this API cover the context string
 "Exported Authenticator" and therefore cannot be transplanted into other
 protocols.
 
-In TLS 1.3 the client and server are not guaranteed to agree on the client’s
-final flight until the first application message.  Because EAs can be
-negotiated out-of-band it is possible to negotiate EAs without agreeing on the
-entire transcript.  Servers SHOULD send application data before sending a
-CertificateRequest to the client.  If there is no application data to send the
-server MAY send a NewSessionTicket.
+In TLS 1.3 the client can not explicitly learn from the TLS layer whether its
+Finished message was accepted. Because the application traffic keys are not
+dependent on the client's final flight, the client cannot learn whether the
+server ever received it.  To avoid disagreement between the client and server
+on the authentication status of EAs, servers MUST verify the client Finished
+before sending an EA or processing a received EA.
 
 # Acknowledgements {#ack}
 

--- a/draft-ietf-tls-exported-authenticator.md
+++ b/draft-ietf-tls-exported-authenticator.md
@@ -511,6 +511,13 @@ The signatures generated with this API cover the context string
 "Exported Authenticator" and therefore cannot be transplanted into other
 protocols.
 
+In TLS 1.3 the client and server are not guaranteed to agree on the client’s
+final flight until the first application message.  Because EAs can be
+negotiated out-of-band it is possible to negotiate EAs without agreeing on the
+entire transcript.  Servers SHOULD send application data before sending an
+CertificateRequest to the client.  If there is no application data to send the
+server MAY send a NewSessionTicket.
+
 # Acknowledgements {#ack}
 
 Comments on this proposal were provided by Martin Thomson.  Suggestions for


### PR DESCRIPTION
In the TLS 1.3 handshake the client and server do not agree on the client's certificate bytes until after the first server application message.
If this is significant to an application, then the server should send an application message before authenticating the client with an EA.